### PR TITLE
New filter

### DIFF
--- a/CEM/_s/splitLines.py
+++ b/CEM/_s/splitLines.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8  -*-
+
+# conda execute
+# env:
+#  - python >=3
+
+import sys, re
+
+def filter():
+    line = sys.stdin.readline()[:-1]
+    pat = re.compile("[.:;]\s+")
+    spat = re.compile("→")
+    while line:
+        structure = spat.split(line)
+        lines = pat.split(structure[1])
+        for l in lines[:-1]:
+            print (structure[0]+"→"+l+".")
+        print(structure[0]+"→"+lines[-1])
+        line = sys.stdin.readline()[:-1]
+
+filter()


### PR DESCRIPTION
Simple filter to split paragraphs into phrases, keeping the original article name prefix.


Only split lines with clean separator. For instance, it split lines in "a. com" and in "a . com" but not in "a.com".

The separators used are dot, colon and semi-colon.